### PR TITLE
Removed line printing points where Ackley function is evaluated.

### DIFF
--- a/GPyOpt/objective_examples/experimentsNd.py
+++ b/GPyOpt/objective_examples/experimentsNd.py
@@ -122,7 +122,6 @@ class ackley:
 
     def f(self,X):
         X = reshape(X,self.input_dim)
-        print(X)
         n = X.shape[0]
         fval = (20+np.exp(1)-20*np.exp(-0.2*np.sqrt((X**2).sum(1)/self.input_dim))-np.exp(np.cos(2*np.pi*X).sum(1)/self.input_dim))
         


### PR DESCRIPTION
Inside the Ackley function class in experimentsNd.py, a line was printing the query point at each function evaluation. This line has been removed.